### PR TITLE
Fixed make warning in make 4.3+

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,17 +19,17 @@ all: $(binary) $(baseline_binary)
 
 
 $(binary): $(objects)
-#	The following is applied automatically
+#	The following implicit rule is applied automatically
 #	$(CC) -o $@ $? $(LDFLAGS)
 
 
 $(baseline_binary): $(baseline_objects)
-#	The following is applied automatically
+#	The following implicit rule is applied automatically
 #	$(CC) -o $@ $? $(LDFLAGS)
 
 
-.c.o: $(headers)
-#	The following is applied automatically
+%.o : %.c $(headers)
+#	The following implicit rule is applied automatically
 #	$(CC) $(CFLAGS) -c $< -o $@
 
 


### PR DESCRIPTION
Replaced the suffix rule with a pattern rule to avoid make warning about "ignoring prerequisites on suffix rule definition"

See
https://www.gnu.org/software/make/manual/html_node/Error-Messages.html https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html